### PR TITLE
Remove unnecessary T parameter from types

### DIFF
--- a/docs/src/manual/new_types.md
+++ b/docs/src/manual/new_types.md
@@ -10,7 +10,7 @@ Suppose we want to define a new shape, which is very much like a rectangle.
 ```julia
 using MultipleScattering
 
-struct MyRectangle{T} <: Shape{T,2}
+struct MyRectangle{T} <: Shape{2}
     origin::Vector{T}
     width::T
     height::T

--- a/src/particle.jl
+++ b/src/particle.jl
@@ -4,19 +4,19 @@ Object we can scatter waves off
 Subtypes will contain information about shape and material properties. Most
 crucially, they will implement the [`t_matrix`](@ref) function
 """
-abstract type AbstractParticle{T,Dim} end
+abstract type AbstractParticle{Dim} end
 
 """
     Particle(medium::PhysicalMedium, shape::Shape)
 
-Create particle with inner medium and shape (types and dimension must agree).
+Create particle with inner medium and shape (dimensions must agree).
 """
-struct Particle{T<:AbstractFloat,Dim,P<:PhysicalMedium,S<:Shape} <: AbstractParticle{T,Dim}
+struct Particle{Dim,P<:PhysicalMedium,S<:Shape} <: AbstractParticle{Dim}
     medium::P
     shape::S
-    # Enforce that the Dims and Types are all the same
-    function Particle{T,Dim,P,S}(medium::P,shape::S) where {T,Dim,FieldDim,P<:PhysicalMedium{T,Dim,FieldDim},S<:Shape{T,Dim}}
-        new{T,Dim,P,S}(medium,shape)
+    # Enforce that the Dims are all the same
+    function Particle{Dim,P,S}(medium::P,shape::S) where {Dim,FieldDim,P<:PhysicalMedium{Dim,FieldDim},S<:Shape{Dim}}
+        new{Dim,P,S}(medium,shape)
     end
 end
 
@@ -36,26 +36,26 @@ end
 
 A particle within another particle, both with the same shape type and origin.
 """
-struct CapsuleParticle{T<:AbstractFloat,Dim,P<:PhysicalMedium,S<:Shape} <: AbstractParticle{T,Dim}
-    outer::Particle{T,Dim,P,S}
-    inner::Particle{T,Dim,P,S}
+struct CapsuleParticle{Dim,P<:PhysicalMedium,S<:Shape} <: AbstractParticle{Dim}
+    outer::Particle{Dim,P,S}
+    inner::Particle{Dim,P,S}
     # Enforce that particles are concentric
-    function CapsuleParticle{T,Dim,P,S}(p2::Particle{T,Dim,P,S},p1::Particle{T,Dim,P,S}) where {T,Dim,P<:PhysicalMedium{T,Dim},S<:Shape}
+    function CapsuleParticle{Dim,P,S}(p2::Particle{Dim,P,S},p1::Particle{Dim,P,S}) where {Dim,P<:PhysicalMedium{Dim},S<:Shape}
         if origin(p1) != origin(p2) error("outer and inner particles should share the same origin") end
         if outer_radius(p1) >= outer_radius(p2)
-            new{T,Dim,P,S}(p1,p2)
+            new{Dim,P,S}(p1,p2)
         else
-            new{T,Dim,P,S}(p2,p1)
+            new{Dim,P,S}(p2,p1)
         end
     end
 end
 
 # Shorthand for all Vectors of particles
-AbstractParticles{T<:AbstractFloat,Dim} = Vector{Pt} where Pt<:AbstractParticle{T,Dim}
+AbstractParticles{Dim} = Vector{Pt} where Pt<:AbstractParticle{Dim}
 
 # Convenience constructor which does not require explicit types/parameters
-function Particle(medium::P,s::S) where {Dim,T,P<:PhysicalMedium{T,Dim},S<:Shape{T,Dim}}
-    Particle{T,Dim,P,S}(medium,s)
+function Particle(medium::P,s::S) where {Dim,P<:PhysicalMedium{Dim},S<:Shape{Dim}}
+    Particle{Dim,P,S}(medium,s)
 end
 
 """
@@ -63,12 +63,12 @@ end
 
 Returns a particle shaped like a sphere or circle, when the particle shape is not given and with the specified `radius`.
 """
-function Particle(medium::P, radius::T) where {T, Dim, P <: PhysicalMedium{T,Dim}}
-    Particle{T,Dim,P,Sphere{T,Dim}}(medium,Sphere(Dim,radius))
+function Particle(medium::P, radius) where {Dim, P <: PhysicalMedium{Dim}}
+    Particle{Dim,P,Sphere{Dim}}(medium,Sphere(Dim,radius))
 end
 
-function CapsuleParticle(p1::Particle{T,Dim,P,S},p2::Particle{T,Dim,P,S}) where {T,Dim,S<:Shape,P<:PhysicalMedium}
-    CapsuleParticle{T,Dim,P,S}(p1,p2)
+function CapsuleParticle(p1::Particle{Dim,P,S},p2::Particle{Dim,P,S}) where {Dim,S<:Shape,P<:PhysicalMedium}
+    CapsuleParticle{Dim,P,S}(p1,p2)
 end
 
 shape(p::Particle) = p.shape
@@ -79,7 +79,7 @@ origin(p::AbstractParticle) = origin(shape(p))
 
 boundary_points(p::AbstractParticle, num_points::Int = 3; kws...) = boundary_points(shape(p),num_points; kws...)
 
-CircleParticle{T,P} = Particle{T,2,P,Sphere{T,2}}
+CircleParticle{T,P} = Particle{2,P,Sphere{T,2}}
 
 outer_radius(p::AbstractParticle) = outer_radius(shape(p))
 volume(p::AbstractParticle) = volume(shape(p))

--- a/src/physics/acoustics/boundary_data.jl
+++ b/src/physics/acoustics/boundary_data.jl
@@ -1,9 +1,11 @@
-function boundary_data(shape1::Shape{T}, inside_medium::Acoustic{T,Dim}, outside_medium::Acoustic{T,Dim},
-        sim::FrequencySimulation{T,Dim,P}, ωs::Vector{T};
-        dr = T(10)^(3*Dim) * eps(T), kws...) where {T<:AbstractFloat,Dim,P<:Acoustic{T,Dim}}
+function boundary_data(shape1::Shape{Dim}, inside_medium::Acoustic{TI,Dim}, outside_medium::Acoustic{TO,Dim},
+        sim::FrequencySimulation, ωs::Vector;
+        dr = 10^(3*Dim) * eps(number_type(shape1)), kws...) where {Dim,TI,TO}
 
     in_m = inside_medium
     out_m = outside_medium
+
+    T = number_type(shape1)
 
     # points just inside particles
     inside1_points = boundary_points(shape1; dr = - dr - 10*eps(T))[:]

--- a/src/physics/acoustics/circle.jl
+++ b/src/physics/acoustics/circle.jl
@@ -1,11 +1,11 @@
-AcousticCircleParticle{T} = Particle{T,2,Acoustic{T,2},Sphere{T,2}}
+AcousticCircleParticle{T} = Particle{2,Acoustic{T,2},Sphere{T,2}}
 
 """
-    t_matrix(Particle{T,2,Acoustic{T,2},Sphere{T,2}}, Acoustic{T,2}, ω, order)
+    t_matrix(Particle{2,Acoustic{T,2},Sphere{T,2}}, Acoustic{T,2}, ω, order)
 
 The T-matrix for a 2D circlular acoustic particle in a 2D acoustic medium.
 """
-function t_matrix(p::Particle{T,2,Acoustic{T,2},Sphere{T,2}}, outer_medium::Acoustic{T,2}, ω::T, basis_order::Integer)::Diagonal{Complex{T}} where T <: AbstractFloat
+function t_matrix(p::Particle{2,Acoustic{T,2},Sphere{T,2}}, outer_medium::Acoustic{T,2}, ω::T, basis_order::Integer)::Diagonal{Complex{T}} where T <: AbstractFloat
 
     # Check for material properties that don't make sense or haven't been implemented
     check_material(p, outer_medium)

--- a/src/physics/acoustics/concentric_capsule.jl
+++ b/src/physics/acoustics/concentric_capsule.jl
@@ -1,10 +1,10 @@
 
 """
-    t_matrix(CapsuleParticle{T,2,Acoustic{T,2},Sphere{T,2}}, Acoustic{T,2}, ω, order)
+    t_matrix(CapsuleParticle{2,Acoustic{T,2},Sphere{T,2}}, Acoustic{T,2}, ω, order)
 
 The T-matrix for a 2D circlular capsule particle in an acoustic medium.
 """
-function t_matrix(cap::CapsuleParticle{T,2,Acoustic{T,2},Sphere{T,2}}, medium::Acoustic{T,2}, ω::T, M::Integer)::Diagonal{Complex{T}} where T <: AbstractFloat
+function t_matrix(cap::CapsuleParticle{2,Acoustic{T,2},Sphere{T,2}}, medium::Acoustic{T,2}, ω::T, M::Integer)::Diagonal{Complex{T}} where T <: AbstractFloat
 
     k = ω / medium.c
     k0 = ω / cap.inner.medium.c
@@ -35,7 +35,7 @@ function t_matrix(cap::CapsuleParticle{T,2,Acoustic{T,2},Sphere{T,2}}, medium::A
     return Diagonal(vcat(reverse(Tns), Tns[2:end]))
 end
 
-function internal_field(x::AbstractArray{T}, p::CapsuleParticle{T,2,Acoustic{T,2},Sphere{T,2}}, source::RegularSource{T,Acoustic{T,2}}, ω::T, scattering_coefficients::AbstractVector) where T
+function internal_field(x::AbstractArray{T}, p::CapsuleParticle{2,Acoustic{T,2},Sphere{T,2}}, source::RegularSource{Acoustic{T,2}}, ω::T, scattering_coefficients::AbstractVector) where T
 
     Nh = Int((length(scattering_coefficients) - one(T))/T(2.0)) #shorthand
 

--- a/src/physics/acoustics/source.jl
+++ b/src/physics/acoustics/source.jl
@@ -3,7 +3,7 @@
 
 Create 2D [`Acoustic`](@ref) point [`RegularSource`](@ref) (zeroth Hankel function of first type)
 """
-function point_source(medium::Acoustic{T,2}, source_position::AbstractVector, amplitude::Union{T,Complex{T},Function} = one(T))::RegularSource{T,Acoustic{T,2}} where T <: AbstractFloat
+function point_source(medium::Acoustic{T,2}, source_position::AbstractVector, amplitude::Union{T,Complex{T},Function} = one(T))::RegularSource{Acoustic{T,2}} where T <: AbstractFloat
 
     # Convert to SVector for efficiency and consistency
     source_position = SVector{2,T}(source_position)
@@ -23,11 +23,11 @@ function point_source(medium::Acoustic{T,2}, source_position::AbstractVector, am
         return (amp(ω)*im)/4 * [hankelh1(-n,k*r) * exp(-im*n*θ) for n = -order:order]
     end
 
-    return RegularSource{T,Acoustic{T,2},WithoutSymmetry{2}}(medium, source_field, source_coef)
+    return RegularSource{Acoustic{T,2},WithoutSymmetry{2}}(medium, source_field, source_coef)
 end
 
 # If we replaced 3 with Dim below this could should work for all dimensions! Test carefully after changing.
-function point_source(medium::Acoustic{T,3}, source_position, amplitude::Union{T,Complex{T},Function} = one(T))::RegularSource{T,Acoustic{T,3}} where T <: AbstractFloat
+function point_source(medium::Acoustic{T,3}, source_position, amplitude::Union{T,Complex{T},Function} = one(T))::RegularSource{Acoustic{T,3}} where T <: AbstractFloat
 
     # Convert to SVector for efficiency and consistency
     source_position = SVector{3,T}(source_position)
@@ -56,13 +56,13 @@ function point_source(medium::Acoustic{T,3}, source_position, amplitude::Union{T
         return amp(ω) * U[1,:]
     end
 
-    return RegularSource{T,Acoustic{T,3},WithoutSymmetry{3}}(medium, source_field, source_coef)
+    return RegularSource{Acoustic{T,3},WithoutSymmetry{3}}(medium, source_field, source_coef)
 end
 
 
 function plane_source(medium::Acoustic{T,Dim}; position::AbstractArray{T} = SVector(zeros(T,Dim)...),
         direction = SVector(one(T), zeros(T,Dim-1)...),
-        amplitude::Union{T,Complex{T},Function} = one(T))::RegularSource{T,Acoustic{T,Dim}} where {T, Dim}
+        amplitude::Union{T,Complex{T},Function} = one(T))::RegularSource{Acoustic{T,Dim}} where {T, Dim}
 
     plane_source(medium, position, direction, amplitude)
 end
@@ -72,7 +72,7 @@ end
 
 Create an [`Acoustic`](@ref) planar wave [`RegularSource`](@ref)
 """
-function plane_source(medium::Acoustic{T,2}, position::AbstractArray{T}, direction::AbstractArray{T} = SVector(one(T),zero(T)), amplitude::Union{T,Complex{T}} = one(T))::RegularSource{T,Acoustic{T,2}} where {T}
+function plane_source(medium::Acoustic{T,2}, position::AbstractArray{T}, direction::AbstractArray{T} = SVector(one(T),zero(T)), amplitude::Union{T,Complex{T}} = one(T))::RegularSource{Acoustic{T,2}} where {T}
 
     # Convert to SVector for efficiency and consistency
     position = SVector(position...)
@@ -99,7 +99,7 @@ function plane_source(medium::Acoustic{T,2}, position::AbstractArray{T}, directi
         source_field(centre,ω) * [exp(im * n *(T(pi)/2 -  θ)) for n = -order:order]
     end
 
-    return RegularSource{T,Acoustic{T,2},S}(medium, source_field, source_coef)
+    return RegularSource{Acoustic{T,2},S}(medium, source_field, source_coef)
 end
 
 function plane_source(medium::Acoustic{T,3}, position::AbstractArray{T}, direction::AbstractArray{T} = SVector(zero(T),zero(T),one(T)), amplitude::Union{T,Complex{T}} = one(T)) where {T}
@@ -135,10 +135,10 @@ function plane_source(medium::Acoustic{T,3}, position::AbstractArray{T}, directi
         for l = 0:order for m = -l:l]
     end
 
-    return RegularSource{T,Acoustic{T,3},S}(medium, source_field, source_coef)
+    return RegularSource{Acoustic{T,3},S}(medium, source_field, source_coef)
 end
 
-function regular_spherical_coefficients(psource::PlaneSource{T,Dim,1,Acoustic{T,Dim}}) where {T,Dim}
+function regular_spherical_coefficients(psource::PlaneSource{T,Dim,1,Acoustic{T,Dim}}) where {Dim,T}
 
     source = plane_source(psource.medium;
         amplitude = psource.amplitude[1],

--- a/src/physics/acoustics/sphere.jl
+++ b/src/physics/acoustics/sphere.jl
@@ -1,9 +1,9 @@
 """
-    t_matrix(Particle{T,3,Acoustic{T,3},Sphere{T,3}}, Acoustic{T,3}, ω, order)
+    t_matrix(Particle{3,Acoustic{T,3},Sphere{T,3}}, Acoustic{T,3}, ω, order)
 
 The T-matrix for a 3D spherical acoustic particle in a 3D acoustic medium.
 """
-function t_matrix(p::Particle{T,3,Acoustic{T,3},Sphere{T,3}}, outer_medium::Acoustic{T,3}, ω::T, basis_order::Integer)::Diagonal{Complex{T}} where T <: AbstractFloat
+function t_matrix(p::Particle{3,Acoustic{T,3},Sphere{T,3}}, outer_medium::Acoustic{T,3}, ω::T, basis_order::Integer)::Diagonal{Complex{T}} where T <: AbstractFloat
 
     # Check for material properties that don't make sense or haven't been implemented
     check_material(p, outer_medium)

--- a/src/physics/electromagnetism.jl
+++ b/src/physics/electromagnetism.jl
@@ -5,10 +5,10 @@
 Represents the physical properties for a homogenous isotropic electromagnetic medium. Produces
 a three dimensional vector field.
 """
-struct Electromagnetic{Dim,T} <: PhysicalMedium{T,Dim,3}
+struct Electromagnetic{Dim,T} <: PhysicalMedium{Dim,3}
     μ::Complex{T} # Permeability
     ε::Complex{T} # Permittivity
     σ::Complex{T} # Conductivity
 end
 
-name(e::Electromagnetic{T,Dim}) where {T,Dim} = "$(Dim)D Electromagnetic"
+name(e::Electromagnetic{Dim,T}) where {Dim,T} = "$(Dim)D Electromagnetic"

--- a/src/physics/physical_medium.jl
+++ b/src/physics/physical_medium.jl
@@ -1,36 +1,32 @@
 """
-    PhysicalMedium{T<:AbstractFloat,Dim,FieldDim}
+    PhysicalMedium{Dim,FieldDim}
 
 An abstract type used to represent the physical medium, the dimension of
 the field, and the number of spatial dimensions.
 """
-abstract type PhysicalMedium{T<:AbstractFloat,Dim,FieldDim} end
+abstract type PhysicalMedium{Dim,FieldDim} end
 
 "Extract the dimension of the field of this physical property"
-field_dimension(p::PhysicalMedium{T,Dim,FieldDim}) where {T,Dim,FieldDim} = FieldDim
+field_dimension(p::PhysicalMedium{Dim,FieldDim}) where {Dim,FieldDim} = FieldDim
 
 "Extract the dimension of the field of this type of physical property"
-field_dimension(p::Type{P}) where {Dim,FieldDim,T,P<:PhysicalMedium{T,Dim,FieldDim}} = FieldDim
+field_dimension(p::Type{P}) where {Dim,FieldDim,P<:PhysicalMedium{Dim,FieldDim}} = FieldDim
 
 "Extract the dimension of the space that this physical property lives in"
-spatial_dimension(p::PhysicalMedium{T,Dim,FieldDim}) where {Dim,FieldDim,T} = Dim
+spatial_dimension(p::PhysicalMedium{Dim,FieldDim}) where {Dim,FieldDim} = Dim
 
 "Extract the dimension of the space that this type of physical property lives in"
-spatial_dimension(p::Type{P}) where {Dim,FieldDim,T,P<:PhysicalMedium{T,Dim,FieldDim}} = Dim
+spatial_dimension(p::Type{P}) where {Dim,FieldDim,P<:PhysicalMedium{Dim,FieldDim}} = Dim
 
 """
 A basis for regular functions, that is, smooth functions. A series expansion in this basis should converge to any regular function within a ball.
 """
-function regular_basis_function(medium::P, ω::T) where {P<:PhysicalMedium,T}
-    error("No regular basis function implemented for this physics type.")
-end
+regular_basis_function
 
 """
 Basis of outgoing wave. A series expansion in this basis should converge to any scattered field outside of a ball which contains the scatterer.
 """
-function outgoing_basis_function(medium::P, ω::T) where {P<:PhysicalMedium,T}
-    error("No outgoing basis function implmented for this physics type.")
-end
+outgoing_basis_function
 
 """
 the field inside an AbstractParticle a some given point x.
@@ -47,9 +43,9 @@ boundary_data
 
 
 """
-    estimate_regular_basis_order(medium::P, ω::Number, radius::Number; tol = 1e-6)
+    estimate_regular_basis_order(medium::PhysicalMedium, ω::Number, radius::Number; tol = 1e-6)
 """
-function estimate_regular_basisorder(medium::P, ω::Number, radius::Number; tol = 1e-6) where P<:PhysicalMedium
+function estimate_regular_basisorder(medium::PhysicalMedium, ω::Number, radius::Number; tol = 1e-6)
 
     @error "This is not complete"
 

--- a/src/plot/plot.jl
+++ b/src/plot/plot.jl
@@ -40,21 +40,21 @@ end
 
 
 "Plot the field for a particular wavenumber"
-@recipe function plot(sim::FrequencySimulation{T,3}, ω::T;
+@recipe function plot(sim::FrequencySimulation{3}, ω::Number;
         res=10, xres=res, yres=res,
         y = :auto,
         field_apply=real,
         region_shape = :auto,
         bounds = :auto,
-        exclude_region = EmptyShape{T,3}(),
-        drawparticles=false) where {T}
+        exclude_region = EmptyShape{3}(),
+        drawparticles=false)
 
     # If user wants us to, generate bounding rectangle around particles
     region_shape = (region_shape != :auto) ? region_shape :
         if isempty(sim.particles)
             if bounds == :auto
                 @warn "What region to plot? For example, use keyword bounds = Box([[-1.0,-1.0],[1.0,1.0]])"
-                Box([[-one(T),-one(T)],[one(T),one(T)]])
+                Box([[-1,-1],[1,1]])
             else bounds
             end
         else
@@ -108,13 +108,13 @@ end
 
 
 "Plot the field for a particular wavenumber"
-@recipe function plot(sim::FrequencySimulation{T,2}, ω::T;
+@recipe function plot(sim::FrequencySimulation{2}, ω::Number;
         res=10, xres=res, yres=res,
         field_apply=real,
         region_shape = :auto,
         bounds = :auto,
-        exclude_region = EmptyShape{T,2}(),
-        drawparticles=false) where {T}
+        exclude_region = EmptyShape{2}(),
+        drawparticles=false)
 
     # If user wants us to, generate bounding rectangle around particles
     region_shape = (region_shape != :auto) ? region_shape :

--- a/src/plot/plot_domain.jl
+++ b/src/plot/plot_domain.jl
@@ -18,7 +18,7 @@ end
 end
 
 
-@recipe function plot(shape::Shape{T,2}) where T
+@recipe function plot(shape::Shape{2})
 
     grid --> false
     xguide --> "x"
@@ -33,7 +33,7 @@ end
 
 end
 
-@recipe function plot(shape::Shape{T,3}) where T
+@recipe function plot(shape::Shape{3})
 
     println("Only the (x,z) coordinates of this shape will be drawn")
 

--- a/src/result.jl
+++ b/src/result.jl
@@ -5,7 +5,7 @@ abstract type SimulationResult{T,Dim,FieldDim} end
 """
 Struct to hold results of a FrequencySimulation
 """
-struct FrequencySimulationResult{T<:AbstractFloat,Dim,FieldDim} <: SimulationResult{T,Dim,FieldDim}
+struct FrequencySimulationResult{T<:Real,Dim,FieldDim} <: SimulationResult{T,Dim,FieldDim}
     "Values of field through space (rows) and angular frequencies (columns)"
     field::Matrix{SVector{FieldDim,Complex{T}}}
     "Positions"

--- a/src/shapes/box.jl
+++ b/src/shapes/box.jl
@@ -3,7 +3,7 @@
 
 A [`Box`](@ref) for 2D and 3D with axis aligned sides, defined by dimensions and origin (at the center).
 """
-struct Box{T,Dim} <: Shape{T,Dim}
+struct Box{T,Dim} <: Shape{Dim}
     origin::SVector{Dim,T}
     dimensions::SVector{Dim,T}
 end
@@ -14,7 +14,7 @@ function Box(origin::AbstractVector{T}, dimensions::AbstractVector{T}) where T
     Box{T,Dim}(origin, dimensions)
 end
 
-function Box(origin::NTuple{Dim,T}, dimensions::NTuple{Dim,T}) where {T,Dim}
+function Box(origin::NTuple{Dim,T}, dimensions::NTuple{Dim,T}) where {Dim,T}
     Box{T,Dim}(origin, dimensions)
 end
 
@@ -47,8 +47,8 @@ function issubset(inner::Box, outer::Box)
 end
 
 import Base.in
-function in(x::AbstractVector, b::Box{T})::Bool where T
-    all(abs.(x .- b.origin) .<= b.dimensions ./ T(2))
+function in(x::AbstractVector, b::Box)::Bool
+    all(abs.(x .- b.origin) .<= b.dimensions ./ 2)
 end
 
 import Base.(==)

--- a/src/shapes/empty_shape.jl
+++ b/src/shapes/empty_shape.jl
@@ -1,16 +1,16 @@
 """
-    EmptyShape{T,Dim}
+    EmptyShape{Dim}
 
 An empty shape with no points.
 """
-struct EmptyShape{T,Dim} <: Shape{T,Dim} end
+struct EmptyShape{Dim} <: Shape{Dim} end
 
-EmptyShape(s::Shape{T,Dim}) where {T,Dim} = EmptyShape{T,Dim}()
+EmptyShape(s::Shape{Dim}) where {Dim} = EmptyShape{Dim}()
 
 name(shape::EmptyShape) = "EmptyShape"
 
-outer_radius(c::EmptyShape{T,Dim}) where {T,Dim} = zero(T)
-volume(shape::EmptyShape{T,Dim}) where {T,Dim} = zero(T)
+outer_radius(c::EmptyShape{Dim}) where {Dim} = 0
+volume(shape::EmptyShape{Dim}) where {Dim} = 0
 
 import Base.issubset
 issubset(c1::Shape, c2::EmptyShape) = false

--- a/src/shapes/halfspace.jl
+++ b/src/shapes/halfspace.jl
@@ -3,7 +3,7 @@
 
 A halfspace defined by all the points ``\\mathbf x`` that satify ``(\\mathbf x - \\mathbf o) \\cdot \\mathbf n < 0`` where ``\\mathbf n`` is the unit normal and ``\\mathbf o`` is the origin.
 """
-struct Halfspace{T,Dim} <: Shape{T,Dim}
+struct Halfspace{T,Dim} <: Shape{Dim}
     normal::SVector{Dim,T} # outward pointing normal vector
     origin::SVector{Dim,T}
 end

--- a/src/shapes/plate.jl
+++ b/src/shapes/plate.jl
@@ -3,7 +3,7 @@
 
 A plate defined by all the points ``\\mathbf x`` that satify ``|(\\mathbf x - \\mathbf o) \\cdot \\mathbf n| < w /2`` where ``\\mathbf n`` is the unit normal, ``\\mathbf o`` is the origin, and ``w`` is the width.
 """
-struct Plate{T,Dim} <: Shape{T,Dim}
+struct Plate{T,Dim} <: Shape{Dim}
     normal::SVector{Dim,T} # a unit vector which is orthogonal to the plate
     width::T # the width
     origin::SVector{Dim,T}
@@ -29,29 +29,29 @@ outer_radius(hs::Plate{T}) where T = T(Inf)
 # end
 
 import Base.in
-function in(x::AbstractVector{T}, p::Plate)::Bool where T
-    abs(dot(x - p.origin, p.normal)) < p.width / T(2)
+function in(x::AbstractVector, p::Plate)::Bool
+    abs(dot(x - p.origin, p.normal)) < p.width / 2
 end
 
 import Base.(==)
-function ==(h1::Plate{T}, h2::Plate{T}) where T
+function ==(h1::Plate, h2::Plate)
     h1.origin == h2.origin &&
     h1.width == h2.width &&
     h1.normal == h2.normal
 end
 
 import Base.isequal
-function isequal(h1::Plate{T}, h2::Plate{T}) where T
+function isequal(h1::Plate, h2::Plate)
     isequal(h1.origin, h2.origin) &&
     isequal(h1.width, h2.width) &&
     isequal(h1.normal, h2.normal)
 end
 
-function iscongruent(h1::Plate{T}, h2::Plate{T}) where T
+function iscongruent(h1::Plate, h2::Plate)
     (h1.normal  == h2.normal) && (h1.width  == h2.width)
 end
 
-function congruent(h::Plate{T}, x) where T
+function congruent(h::Plate, x)
     Plate(h.normal, h.width, x)
 end
 

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -3,7 +3,7 @@
 
 A [`Shape`](@ref) where boundary is a fixed distance from the origin. In 2D this is a circle, in 3D the usual sphere, and in higher dimensions if difficult to visualise.
 """
-struct Sphere{T,Dim} <: Shape{T,Dim}
+struct Sphere{T,Dim} <: Shape{Dim}
     origin::SVector{Dim,T}
     radius::T
 end
@@ -27,8 +27,8 @@ volume(shape::Sphere{T,3}) where T = 4//3 * π * shape.radius^3
 volume(shape::Sphere{T,2}) where T = π * shape.radius^2
 
 # bounding_box(sphere::Sphere{T,3}; kws...) where T = bounding_box(Circle(sphere; kws...))
-function bounding_box(sphere::Sphere{T,Dim}) where {T,Dim}
-    return Box(origin(sphere), T(2)*sphere.radius .* ones(T,Dim))
+function bounding_box(sphere::Sphere)
+    return Box(origin(sphere), fill(2*sphere.radius, dim(sphere)))
 end
 
 import Base.in
@@ -37,7 +37,7 @@ function in(x::AbstractVector, sphere::Sphere)::Bool
 end
 
 import Base.issubset
-function issubset(inner_sphere::Sphere{T,Dim}, outer_sphere::Sphere{T,Dim}) where {T,Dim}
+function issubset(inner_sphere::Sphere, outer_sphere::Sphere)
     norm(origin(outer_sphere) - origin(inner_sphere)) <= outer_sphere.radius - inner_sphere.radius
 end
 
@@ -70,12 +70,12 @@ function congruent(s::Sphere, x)
     Sphere(x, s.radius)
 end
 
-function Circle(sphere::Sphere{T}; y = sphere.origin[2]) where T
+function Circle(sphere::Sphere; y = sphere.origin[2])
     if abs(y - sphere.origin[2]) > sphere.radius
         return EmptyShape(sphere)
     else
         r = sqrt(sphere.radius^2 - (sphere.origin[2] - y)^2)
-        return Sphere{T,2}(sphere.origin[[1,3]], r)
+        return Sphere{number_type(sphere),2}(sphere.origin[[1,3]], r)
     end
 end
 

--- a/src/shapes/time_of_flight.jl
+++ b/src/shapes/time_of_flight.jl
@@ -6,13 +6,13 @@ is defined as
 ``(y - y_f)^2 < (D + x_0)^2 - x_f^2 - 2(D + x_0 - x_f)x``  and ``x > min(x_0, x_f)``
 where ``D`` is the focal distance.
 """
-struct TimeOfFlightPlaneWaveToPoint{T <: AbstractFloat,Dim} <: Shape{T,Dim}
+struct TimeOfFlightPlaneWaveToPoint{T <: AbstractFloat,Dim} <: Shape{Dim}
     focal_point::AbstractVector{T}
     focal_distance::T
     minimum_x::T
 end
 
-TimeOfFlightPlaneWaveToPoint(focal_point::AbstractVector{T},  focal_distance::T;  minimum_x::T = zero(T)) where T <:AbstractFloat = TimeOfFlightPlaneWaveToPoint{T,length(focal_point)}(focal_point, focal_distance, minimum_x)
+TimeOfFlightPlaneWaveToPoint(focal_point::AbstractVector{T},  focal_distance::T;  minimum_x::T = zero(eltype(focal_point))) where T <:AbstractFloat = TimeOfFlightPlaneWaveToPoint{T,length(focal_point)}(focal_point, focal_distance, minimum_x)
 
 name(shape::TimeOfFlightPlaneWaveToPoint) = "Time of flight from planar source to the focal point"
 

--- a/src/shapes/time_of_flight_from_point.jl
+++ b/src/shapes/time_of_flight_from_point.jl
@@ -7,7 +7,7 @@ More precisely, if the listener is at (l_x,l_y) then the interior of the shape
 is defined as
 sqrt((x-l_x)^2+(y-l_y)^2)<time and x>0
 """
-struct TimeOfFlightPointWaveToPoint{T <: AbstractFloat} <: Shape{T,2}
+struct TimeOfFlightPointWaveToPoint{T <: AbstractFloat} <: Shape{2}
     listener_position::Vector{T}
     time::T
 end
@@ -20,15 +20,15 @@ function volume(shape::TimeOfFlightPointWaveToPoint)
 end
 
 import Base.issubset
-function issubset(circle::Sphere{T,2}, shape::TimeOfFlightPointWaveToPoint) where T
+function issubset(circle::Sphere{2}, shape::TimeOfFlightPointWaveToPoint)
     (origin(circle)[1] - circle.radius) > 0 &&
     norm(origin(circle) - shape.listener_position) < (shape.time - 2circle.radius)
 end
 
-function bounding_box(shape::TimeOfFlightPointWaveToPoint{T}) where T <: AbstractFloat
+function bounding_box(shape::TimeOfFlightPointWaveToPoint)
     box_height = 2sqrt(shape.time^2 - shape.listener_position[1]^2)
-    box_width = max(shape.time + shape.listener_position[1], zero(T))
-    return Box([SVector(zero(T), -box_height/2), SVector(box_width, box_height/2)])
+    box_width = max(shape.time + shape.listener_position[1], 0)
+    return Box([SVector(zero(box_width), -box_height/2), SVector(box_width, box_height/2)])
 end
 
 

--- a/src/t_matrix.jl
+++ b/src/t_matrix.jl
@@ -3,7 +3,7 @@
 
 Returns a finite T-matrix, with size depending on `order`, for a specific `particle` within a `medium` with specific physical properties.
 """
-function t_matrix(p::AbstractParticle{T,Dim}, medium::PhysicalMedium{T,Dim}, ω::T, order::Integer)::AbstractMatrix{T} where {T<:AbstractFloat,Dim}
+function t_matrix(p::AbstractParticle{Dim}, medium::PhysicalMedium{Dim}, ω::T, order::Integer)::AbstractMatrix{T} where {T<:AbstractFloat,Dim}
 
     error("T-matrix function is not yet written for $(name(p.medium)) $(name(p.shape)) in a $(name(medium)) medium")
 end

--- a/test/particle_tests.jl
+++ b/test/particle_tests.jl
@@ -12,8 +12,7 @@
 
         # Check types comparisons work as user would expect
         @test typeof(homog_particles) <: AbstractParticles
-        @test typeof(homog_particles) <: AbstractParticles{Float64}
-        @test typeof(homog_particles) <: AbstractParticles{Float64,2}
+        @test typeof(homog_particles) <: AbstractParticles{2}
 
         circle = Sphere((0.0,0.0),1.0)
         rect = Box((2.0,2.0),(3.0,2.0))
@@ -21,18 +20,17 @@
 
         # Check types comparisons work as user would expect
         @test typeof(diff_shape_particles) <: AbstractParticles
-        @test typeof(diff_shape_particles) <: AbstractParticles{Float64}
-        @test typeof(diff_shape_particles) <: AbstractParticles{Float64,2}
+        @test typeof(diff_shape_particles) <: AbstractParticles{2}
 
         a2 = Acoustic(1.0,1.0,2)
         a3 = Acoustic(1.0,1.0,3)
         sphere = Sphere((0.0,0.0,0.0),1.0)
 
         circular_particle = Particle(a2,circle)
-        @test typeof(circular_particle) <: Particle{Float64,2}
+        @test typeof(circular_particle) <: Particle{2}
 
         spherical_particle = Particle(a3,sphere)
-        @test typeof(spherical_particle) <: AbstractParticle{Float64,3}
+        @test typeof(spherical_particle) <: AbstractParticle{3}
 
         # Dimension mismatch throws error
         @test_throws MethodError Particle(a3,circle)
@@ -41,10 +39,10 @@
         # This is a valid vector of valid particles, but not of type Particles
         # because the dimensions don't match
         invalid_particles = [circular_particle, spherical_particle]
-        @test_throws TypeError invalid_particles::(Vector{Pt} where {Dim, Pt <: AbstractParticle{Float64,Dim}})
+        @test_throws TypeError invalid_particles::(Vector{Pt} where {Dim, Pt <: AbstractParticle{Dim}})
 
         # does not throw an error
-        diff_shape_particles::(Vector{Pt} where {Dim, Pt <: AbstractParticle{Float64,Dim}})
+        diff_shape_particles::(Vector{Pt} where {Dim, Pt <: AbstractParticle{Dim}})
         @test true
 
     end
@@ -124,6 +122,6 @@ end
     a_out = Acoustic(3.0,3.0,2)
     a = Acoustic(1.0,1.0,2)
     concen_particles = [ Particle(a_out,circle_out),Particle(a,circle_in)]
-    @test typeof(CapsuleParticle(concen_particles...)) <: AbstractParticle{Float64,2}
+    @test typeof(CapsuleParticle(concen_particles...)) <: AbstractParticle{2}
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ import StaticArrays: SVector
 using MultipleScattering
 using LinearAlgebra
 using Plots
+import Statistics: mean
 
 include("special_functions.jl")
 

--- a/test/symmetrytests.jl
+++ b/test/symmetrytests.jl
@@ -13,7 +13,7 @@
     s2 = plane_source(a2; position = source_position, direction = [1.0,0.0])
 
     # NOTE: should use the function regular_spherical_source, but for 2D one of the translation matrices has not been implemented yet
-    s3 = RegularSource{Float64,Acoustic{Float64,2},RadialSymmetry{2}}(a2, (x,ω) -> norm(x)+1.0im, (order,centre,ω) -> [1.0+1.0im for m = -order:order])
+    s3 = RegularSource{Acoustic{Float64,2},RadialSymmetry{2}}(a2, (x,ω) -> norm(x)+1.0im, (order,centre,ω) -> [1.0+1.0im for m = -order:order])
 
     sources2D = [s1,s2,s3]
 


### PR DESCRIPTION
Progress towards fixing #33 

There were a lot more changes than I initially thought, changing the abstract types had a lot of knock on effects. There's probably more `T`s that can be taken out, but this seemed like a good place to stop, and the unit tests pass.

- Remove T parameter from all abstract types: Shape, PhysicalMedium,
  AbstractSource
- Remove T from singleton types: EmptyShape
- Remove T from RegularSource
- Remove Ts from many functions due to taking out T from abstract types.
  Diagonal dispatch was probably unnecessarily restrictive, and types
  should have been inferred where necessary.